### PR TITLE
Document Nphase in the UVH5 Memo

### DIFF
--- a/docs/references/uvh5_memo.tex
+++ b/docs/references/uvh5_memo.tex
@@ -206,6 +206,8 @@ interoperability between different HDF5 implementations.
   ECEF. The conversion between LLA and ECEF is given by WGS84. This is a
   two-dimensional array of size (Nants\_telescope,
   3). (\textit{antenna\_positions})
+\item \textbf{Nphase}: \textit{int} The number of phase centers present in the
+  \textit{phase\_center\_catalog}. (\textit{Nphase})
 \item \textbf{phase\_center\_catalog}: A series of nested datasets, similar to
 a dict in python (\textit{phase\_center\_catalog}). The top level keys are integers
 giving the phase center catalog IDs which are used to identify which


### PR DESCRIPTION
## Description
Add an entry for the `Nphase` Header dataset, just above the related `phase_center_catalog` entry in the UVH5 Memo tex file.

## Motivation and Context
Without `Nphase` v1.1 UVH5 files cannot be interpreted (#1224).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
- [ ] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.

Documentation change checklist:
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)